### PR TITLE
Cleanup enums, clarifying & renaming to more conventional style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# environment settings from https://direnv.net/
+.direnv/
+.envrc

--- a/src/machines/endpoints.rs
+++ b/src/machines/endpoints.rs
@@ -2,7 +2,7 @@ use crate::machines::{
     MachineConfig,
     MachineRegion,
     // Checks, DnsConfig, FileConfig, GuestConfig, Header, InitConfig,
-    // MetricsConfig, MountConfig, ProcessConfig, RestartPolicy, ServiceConfig, StaticConfig,
+    // MetricsConfig, MountConfig, ProcessConfig, MachineRestart, ServiceConfig, StaticConfig,
     // StopConfig, TimeoutConfig,
 };
 use serde::{Deserialize, Serialize};
@@ -69,7 +69,7 @@ pub struct MachineResponse {
     pub config: Option<MachineConfig>,
     pub created_at: Option<String>,
     pub events: Option<Vec<EventResponse>>,
-    pub host_status: Option<HostStatusEnum>,
+    pub host_status: Option<HostStatus>,
     pub image_ref: Option<ImageRef>,
     pub incomplete_config: Option<Value>,
     pub instance_id: Option<String>,
@@ -93,7 +93,7 @@ pub struct EventResponse {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "lowercase")]
-pub enum HostStatusEnum {
+pub enum HostStatus {
     Ok,
     Unknown,
     Unreachable,

--- a/src/machines/machine.rs
+++ b/src/machines/machine.rs
@@ -1,6 +1,6 @@
 use crate::machines::{
-    Checks, CpuKind, DnsConfig, FileConfig, GpuKind, GuestConfig, InitConfig, MetricsConfig,
-    MountConfig, ProcessConfig, RestartPolicy, RestartPolicyEnum, ServiceConfig, StaticConfig,
+    Checks, CpuKind, DnsConfig, FileConfig, GpuKind, GuestConfig, InitConfig, MachineRestart,
+    MetricsConfig, MountConfig, ProcessConfig, RestartPolicy, ServiceConfig, StaticConfig,
     StopConfig,
 };
 use serde::{Deserialize, Serialize};
@@ -36,7 +36,7 @@ pub struct MachineConfig {
     pub env: Option<HashMap<String, String>>,
     pub processes: Option<Vec<ProcessConfig>>,
     pub mounts: Option<Vec<MountConfig>>,
-    pub restart: Option<RestartPolicy>,
+    pub restart: Option<MachineRestart>,
     pub checks: Option<Checks>,
     pub dns: Option<DnsConfig>,
     pub files: Option<Vec<FileConfig>>,
@@ -83,7 +83,7 @@ impl MachineConfig {
         image: String,
         auto_destroy: Option<bool>,
         guest: Option<GuestConfig>,
-        restart: Option<RestartPolicy>,
+        restart: Option<MachineRestart>,
         env: Option<HashMap<String, String>>,
         processes: Option<Vec<ProcessConfig>>,
         mounts: Option<Vec<MountConfig>>,
@@ -131,7 +131,7 @@ impl MachineConfigBuilder {
             config: MachineConfig {
                 image: "ubuntu:22.04".to_string(),
                 auto_destroy: Some(false),
-                restart: Some(RestartPolicy::default()),
+                restart: Some(MachineRestart::default()),
                 guest: Some(GuestConfig::default()),
                 ..Default::default()
             },
@@ -150,12 +150,12 @@ impl MachineConfigBuilder {
 
     pub fn restart_policy(
         mut self,
-        policy: RestartPolicyEnum,
+        policy: RestartPolicy,
         max_retries: Option<u32>,
         gpu_bid_price: Option<f64>,
     ) -> Self {
-        self.config.restart = Some(RestartPolicy {
-            policy: policy,
+        self.config.restart = Some(MachineRestart {
+            policy,
             max_retries,
             gpu_bid_price,
         });

--- a/src/machines/process.rs
+++ b/src/machines/process.rs
@@ -16,12 +16,12 @@ pub struct ProcessConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EnvVarConfig {
     pub env_var: String,
-    pub field_ref: FieldRefEnum,
+    pub field_ref: FieldRef,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "lowercase")]
-pub enum FieldRefEnum {
+pub enum FieldRef {
     Id,
     Version,
     AppName,

--- a/src/machines/resources.rs
+++ b/src/machines/resources.rs
@@ -87,25 +87,25 @@ pub enum GpuKind {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct RestartPolicy {
+pub struct MachineRestart {
     pub gpu_bid_price: Option<f64>,
     pub max_retries: Option<u32>,
-    pub policy: RestartPolicyEnum,
+    pub policy: RestartPolicy,
 }
 
-impl Default for RestartPolicy {
+impl Default for MachineRestart {
     fn default() -> Self {
         Self {
             gpu_bid_price: None,
             max_retries: None,
-            policy: RestartPolicyEnum::No,
+            policy: RestartPolicy::No,
         }
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "lowercase")]
-pub enum RestartPolicyEnum {
+pub enum RestartPolicy {
     No,
     Always,
     #[serde(rename = "on-failure")]

--- a/src/machines/services.rs
+++ b/src/machines/services.rs
@@ -6,7 +6,7 @@ pub struct ServiceConfig {
     pub autostart: Option<bool>,
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_autostop")]
-    pub autostop: Option<AutostopEnum>,
+    pub autostop: Option<AutostopSetting>,
     pub concurrency: Option<ConcurrencyConfig>,
     pub ports: Option<Vec<MachinePort>>,
     pub internal_port: Option<u16>,
@@ -14,7 +14,7 @@ pub struct ServiceConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "lowercase")]
-pub enum AutostopEnum {
+pub enum AutostopSetting {
     Off,
     Stop,
     Suspend,
@@ -29,7 +29,7 @@ pub struct ConcurrencyConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "lowercase")]
-pub enum ConcurrencyTypeEnum {
+pub enum ConcurrencyType {
     Connections,
     Requests,
 }
@@ -71,25 +71,27 @@ pub struct TlsOptions {
     pub versions: Option<Vec<String>>,
 }
 
-fn deserialize_autostop<'de, D>(deserializer: D) -> Result<Option<AutostopEnum>, D::Error>
+fn deserialize_autostop<'de, D>(deserializer: D) -> Result<Option<AutostopSetting>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
     match value {
         // Older fly apps will have boolean values in their config
-        serde_json::Value::Bool(false) => Ok(Some(AutostopEnum::Off)),
-        serde_json::Value::Bool(true) => Ok(Some(AutostopEnum::Stop)),
+        serde_json::Value::Bool(false) => Ok(Some(AutostopSetting::Off)),
+        serde_json::Value::Bool(true) => Ok(Some(AutostopSetting::Stop)),
         // Newer fly apps use the string variant
         serde_json::Value::String(ref s) if s.eq_ignore_ascii_case("off") => {
-            Ok(Some(AutostopEnum::Off))
+            Ok(Some(AutostopSetting::Off))
         }
         serde_json::Value::String(ref s) if s.eq_ignore_ascii_case("stop") => {
-            Ok(Some(AutostopEnum::Stop))
+            Ok(Some(AutostopSetting::Stop))
         }
         serde_json::Value::String(ref s) if s.eq_ignore_ascii_case("suspend") => {
-            Ok(Some(AutostopEnum::Suspend))
+            Ok(Some(AutostopSetting::Suspend))
         }
-        _ => Err(serde::de::Error::custom("Invalid value for AutostopEnum")),
+        _ => Err(serde::de::Error::custom(
+            "Invalid value for AutostopSetting",
+        )),
     }
 }


### PR DESCRIPTION
This also adds some things to `.gitignore` just because I personally use direnv, and these are hanging around in my local copy.

I have a few other PRs already stacked after this one, but since as far as I know Github doesn't have a good workflow for stacked PRs, we can review/discuss one at a time unless you're okay with me opening all of them now.

I renamed what is currently `RestartPolicy` to `MachineRestart` because this is what Fly API calls this particular bit of configuration, and having both the struct and one of its inner fields sound like the "machine restart policy" is confusing.