### PR TITLE
Add ability to specify network protocols in services

### DIFF
--- a/src/machines/services.rs
+++ b/src/machines/services.rs
@@ -9,6 +9,7 @@ pub struct ServiceConfig {
     pub autostop: Option<AutostopSetting>,
     pub concurrency: Option<ConcurrencyConfig>,
     pub ports: Option<Vec<MachinePort>>,
+    pub protocol: Option<NetworkProtocol>,
     pub internal_port: Option<u16>,
 }
 
@@ -32,6 +33,13 @@ pub struct ConcurrencyConfig {
 pub enum ConcurrencyType {
     Connections,
     Requests,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NetworkProtocol {
+    Tcp,
+    Udp,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Simple change to allow specifying network protocol in services w/Machines API, to create machines that operate on raw TCP/UDP level.