### PR TITLE
Account for more possible Machine states

### DIFF
--- a/src/machines/endpoints.rs
+++ b/src/machines/endpoints.rs
@@ -1,6 +1,7 @@
 use crate::machines::{
     MachineConfig,
     MachineRegion,
+    MachineState,
     // Checks, DnsConfig, FileConfig, GuestConfig, Header, InitConfig,
     // MetricsConfig, MountConfig, ProcessConfig, MachineRestart, ServiceConfig, StaticConfig,
     // StopConfig, TimeoutConfig,
@@ -27,9 +28,9 @@ pub struct MachineRequest {
 impl MachineRequest {
     pub fn new(config: MachineConfig, name: Option<String>, region: Option<MachineRegion>) -> Self {
         Self {
-            name: name,
+            name,
             config,
-            region: region,
+            region,
             lease_ttl: None,
             lsvd: None,
             skip_launch: None,
@@ -77,7 +78,7 @@ pub struct MachineResponse {
     pub nonce: Option<String>,
     pub private_ip: Option<String>,
     pub region: Option<MachineRegion>,
-    pub state: Option<String>,
+    pub state: Option<MachineState>,
     pub updated_at: Option<String>,
 }
 

--- a/src/machines/machine.rs
+++ b/src/machines/machine.rs
@@ -9,19 +9,34 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum MachineState {
+    Created,
+    Starting,
     Started,
+    Stopping,
     Stopped,
+    Suspending,
     Suspended,
+    Replacing,
+    Replaced,
+    Destroying,
     Destroyed,
 }
 
 impl std::fmt::Display for MachineState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use MachineState::*;
         let state_str = match self {
-            MachineState::Started => "started",
-            MachineState::Stopped => "stopped",
-            MachineState::Suspended => "suspended",
-            MachineState::Destroyed => "destroyed",
+            Created => "created",
+            Starting => "starting",
+            Started => "started",
+            Stopping => "stopping",
+            Stopped => "stopped",
+            Suspending => "suspending",
+            Suspended => "suspended",
+            Replacing => "replacing",
+            Replaced => "replaced",
+            Destroying => "destroying",
+            Destroyed => "destroyed",
         };
         write!(f, "{}", state_str)
     }

--- a/src/machines/services.rs
+++ b/src/machines/services.rs
@@ -9,6 +9,7 @@ pub struct ServiceConfig {
     pub autostop: Option<AutostopSetting>,
     pub concurrency: Option<ConcurrencyConfig>,
     pub ports: Option<Vec<MachinePort>>,
+    pub protocol: Option<NetworkProtocol>,
     pub internal_port: Option<u16>,
 }
 
@@ -32,6 +33,13 @@ pub struct ConcurrencyConfig {
 pub enum ConcurrencyType {
     Connections,
     Requests,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NetworkProtocol {
+    Tcp,
+    Udp,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Requires #10 ! (stacked PR)

Changes described by full commit message. There are many more states a fly machine can be in, according to https://fly.io/docs/machines/machine-states/

I also included 1 state which is undocumented, but which I have observed as mentioned in the commit and in this Github issue: https://github.com/superfly/docs/issues/1835